### PR TITLE
Add YouTube videos + schema to homepage, auto & homeowners pages

### DIFF
--- a/auto-insurance.html
+++ b/auto-insurance.html
@@ -30,6 +30,70 @@
     }
     </script>
 
+    <!-- Structured Data: VideoObject -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "License Points vs Insurance Points in NC — Why That Ticket Is Costing You WAY More Than You Think",
+        "description": "Most NC drivers don't realize DMV points and insurance points are completely different systems. Learn how one ticket can silently raise your rates for years.",
+        "thumbnailUrl": "https://img.youtube.com/vi/CjvuPNiLXho/maxresdefault.jpg",
+        "uploadDate": "2025-01-01",
+        "contentUrl": "https://www.youtube.com/watch?v=CjvuPNiLXho",
+        "embedUrl": "https://www.youtube.com/embed/CjvuPNiLXho",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Bill Layne Insurance Agency",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://www.billlayneinsurance.com/images/logo.png"
+            }
+        }
+    }
+    </script>
+
+    <!-- Structured Data: FAQPage -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "How much auto insurance do I need in NC?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "While NC requires minimum coverage of 50/100/50, we recommend at least 100/300/100 to better protect your assets. If you have a loan, you'll also need comprehensive and collision coverage."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "What factors affect my auto insurance rates?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Your rates are based on driving record, age, vehicle type, coverage levels, credit score, and location. We work with multiple carriers to find you the best rate regardless of these factors."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Can I get insurance with a bad driving record?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes! We specialize in finding coverage for all drivers, including those with violations, accidents, or SR-22 requirements. Our carriers offer options for every situation."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "How can I lower my auto insurance premium?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Bundle with home insurance, maintain a clean driving record, choose higher deductibles, ask about discounts (good student, safe driver, multi-car), and review your coverage annually with us."
+                }
+            }
+        ]
+    }
+    </script>
+
     <!-- Cache Control for HTML (reasonable caching) -->
     <meta http-equiv="Cache-Control" content="max-age=3600, must-revalidate">
 
@@ -430,6 +494,18 @@
                 <div class="md:w-1/2">
                     <img src="https://github.com/BillLayne/bill-layne-images/blob/main/logos/Car%20Insurance.png?raw=true" alt="Auto Insurance Protection" class="rounded-lg shadow-xl">
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- VIDEO: License Points vs Insurance Points -->
+    <section class="py-12 md:py-16 bg-slate-50">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+            <span class="inline-block bg-red-100 text-red-700 text-xs font-bold px-3 py-1 rounded-full mb-4 uppercase tracking-wider">Must Watch</span>
+            <h2 class="text-2xl md:text-3xl font-display font-bold text-slate-900 mb-4">License Points vs. Insurance Points — Why That Ticket Costs WAY More Than You Think</h2>
+            <p class="text-slate-600 mb-8 max-w-2xl mx-auto">Most NC drivers don't realize DMV points and insurance points are completely different systems. This video explains how one ticket can silently raise your rates for years.</p>
+            <div class="relative w-full rounded-2xl overflow-hidden shadow-xl" style="padding-bottom:56.25%">
+                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/CjvuPNiLXho?si=r0no6mEXAAFLKIKn" title="License Points vs Insurance Points in NC" frameborder="0" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
     </section>

--- a/homeowners-insurance.html
+++ b/homeowners-insurance.html
@@ -148,6 +148,28 @@
     }
     </script>
 
+    <!-- Structured Data: VideoObject -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "Why Your $10k Ring Only Pays $1,500 in NC - Insurance Secrets",
+        "description": "Most homeowners don't know about sub-limits buried in their policy. Learn why your valuables may not be fully covered and what you can do about it.",
+        "thumbnailUrl": "https://img.youtube.com/vi/7BrR_GnPOrw/maxresdefault.jpg",
+        "uploadDate": "2025-01-01",
+        "contentUrl": "https://www.youtube.com/watch?v=7BrR_GnPOrw",
+        "embedUrl": "https://www.youtube.com/embed/7BrR_GnPOrw",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Bill Layne Insurance Agency",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://www.billlayneinsurance.com/images/logo.png"
+            }
+        }
+    }
+    </script>
+
     <!-- Resource Hints for Performance -->
     <!-- DNS Prefetch for external resources -->
     <link rel="dns-prefetch" href="//fonts.googleapis.com">
@@ -668,6 +690,18 @@
                         <p class="text-gray-600">We strongly recommend replacement cost coverage for your dwelling and personal property. Actual cash value (ACV) policies deduct depreciation, which means you receive far less when filing a claim on older items. The small premium difference between RCV and ACV coverage is well worth the investment.</p>
                     </div>
                 </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- VIDEO: Sub-Limits Explained -->
+    <section class="py-12 md:py-16 bg-slate-50">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+            <span class="inline-block bg-amber-100 text-amber-700 text-xs font-bold px-3 py-1 rounded-full mb-4 uppercase tracking-wider">Eye-Opening</span>
+            <h2 class="text-2xl md:text-3xl font-display font-bold text-slate-900 mb-4">Why Your $10,000 Ring Only Pays $1,500 — NC Insurance Secrets</h2>
+            <p class="text-slate-600 mb-8 max-w-2xl mx-auto">Most homeowners don't know about sub-limits buried in their policy. Watch this before you assume your valuables are fully covered.</p>
+            <div class="relative w-full rounded-2xl overflow-hidden shadow-xl" style="padding-bottom:56.25%">
+                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/7BrR_GnPOrw?si=ixjZ2kMkeVrPZ_Kp" title="Why Your $10k Ring Only Pays $1,500 in NC - Insurance Secrets" frameborder="0" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -426,6 +426,28 @@
     }
     </script>
 
+    <!-- Structured Data: VideoObject -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "VideoObject",
+        "name": "1-800 Number vs Independent Agent — There's a Clear Winner",
+        "description": "See the real difference between calling a faceless 1-800 number and working with a local independent insurance agent who fights for you.",
+        "thumbnailUrl": "https://img.youtube.com/vi/XySGoor0oxI/maxresdefault.jpg",
+        "uploadDate": "2025-01-01",
+        "contentUrl": "https://www.youtube.com/watch?v=XySGoor0oxI",
+        "embedUrl": "https://www.youtube.com/embed/XySGoor0oxI",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Bill Layne Insurance Agency",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://www.billlayneinsurance.com/images/logo.png"
+            }
+        }
+    }
+    </script>
+
     <!-- Fonts & Icons -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -954,6 +976,18 @@
                 <a href="get-quote.html" class="inline-flex items-center gap-3 bg-gradient-to-r from-green-600 to-emerald-600 hover:from-green-700 hover:to-emerald-700 text-white px-8 py-4 rounded-2xl font-bold shadow-xl shadow-green-500/20 transition-all hover:scale-105">
                     <i class="fas fa-exchange-alt"></i> Make the Easy Switch
                 </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- VIDEO: Why Independent Agents Win -->
+    <section class="py-12 md:py-16 bg-slate-50">
+        <div class="max-w-4xl mx-auto px-4 sm:px-6 text-center reveal">
+            <span class="inline-block bg-blue-100 text-blue-700 text-xs font-bold px-3 py-1 rounded-full mb-4 uppercase tracking-wider">Watch & Learn</span>
+            <h2 class="text-2xl md:text-3xl font-display font-bold text-slate-900 mb-4">Why an Independent Agent Beats a 1-800 Number Every Time</h2>
+            <p class="text-slate-600 mb-8 max-w-2xl mx-auto">See the real difference between calling a faceless 1-800 number and working with a local agent who fights for YOU.</p>
+            <div class="relative w-full rounded-2xl overflow-hidden shadow-xl" style="padding-bottom:56.25%">
+                <iframe class="absolute inset-0 w-full h-full" src="https://www.youtube.com/embed/XySGoor0oxI?si=wSQrCbHYDuxoNmAe" title="1-800 Number vs Independent Agent — There's a Clear Winner" frameborder="0" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- Embeds 3 YouTube videos on the 3 highest-traffic pages (homepage, auto insurance, homeowners insurance)
- Adds VideoObject schema markup for Google rich results on all 3 pages
- Adds FAQPage schema to auto-insurance page (4 FAQ questions were visible but had no schema)

## Video Placements
| Page | Video | Purpose |
|------|-------|---------|
| Homepage | 1-800 Number vs Independent Agent | Conversion — proves Bill Layne's value |
| Auto Insurance | License Points vs Insurance Points | Education — keeps visitors on page |
| Homeowners | $10k Ring Only Pays $1,500 | Eye-opener — drives calls for coverage review |

## Test plan
- [ ] Verify all 3 videos load and play on mobile + desktop
- [ ] Verify responsive 16:9 aspect ratio on all breakpoints
- [ ] Validate schema with Google Rich Results Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)