### PR TITLE
Add lifestyle images, coverage icons, and carrier hover effects

### DIFF
--- a/css/mobile-dock.css
+++ b/css/mobile-dock.css
@@ -197,7 +197,7 @@
    MOBILE HERO (index.html only)
 ============================= */
 .mobile-hero {
-    background: linear-gradient(168deg, #0a1628 0%, #122244 40%, #1a3460 100%);
+    background: url("https://i.imgur.com/DDGMV4c.png") center 35% / cover no-repeat;
     position: relative;
     overflow: hidden;
     padding: 22px 20px 24px;
@@ -206,8 +206,7 @@
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(ellipse at 80% 20%, rgba(37,99,235,0.12) 0%, transparent 60%),
-                radial-gradient(ellipse at 20% 80%, rgba(245,158,11,0.06) 0%, transparent 50%);
+    background: linear-gradient(168deg, rgba(10,22,40,0.80) 0%, rgba(18,34,68,0.75) 40%, rgba(26,52,96,0.72) 100%);
     pointer-events: none;
 }
 .mobile-hero::after {

--- a/index.html
+++ b/index.html
@@ -660,10 +660,10 @@
 
     <!-- DESKTOP HERO SECTION (hidden on mobile <768px) -->
     <header id="home" class="-mt-20 relative pt-24 pb-8 md:pt-40 md:pb-24 bg-vivid-hero text-white overflow-hidden hidden md:min-h-[80vh] md:flex items-center">
-        <!-- BACKGROUND -->
+        <!-- BACKGROUND — NC Blue Ridge Mountains lifestyle image -->
         <div class="absolute inset-0 z-0 pointer-events-none">
-            <img src="https://i.imgur.com/ayxaUyZ.jpeg" alt="Bill Layne shaking hands with a client" class="w-full h-full object-cover opacity-20 mix-blend-overlay" style="object-position: center 30%;" fetchpriority="high">
-            <div class="absolute inset-0 bg-gradient-to-b from-slate-900/70 via-slate-900/85 to-slate-900/95"></div>
+            <img src="https://i.imgur.com/DDGMV4c.png" alt="Pilot Mountain at sunset in North Carolina with rolling green foothills" class="w-full h-full object-cover" style="object-position: center 35%;" fetchpriority="high">
+            <div class="absolute inset-0 bg-gradient-to-b from-primary-900/50 via-slate-900/70 to-slate-900/90"></div>
         </div>
 
         <!-- SHAPES -->
@@ -761,25 +761,35 @@
     </header>
 
     <!-- CARRIER WALL - Authorized Agent Logos -->
+    <style>
+        .carrier-logo {
+            filter: grayscale(100%) opacity(0.6);
+            transition: filter 0.4s ease, transform 0.3s ease;
+        }
+        .carrier-logo:hover {
+            filter: grayscale(0%) opacity(1);
+            transform: scale(1.1);
+        }
+    </style>
     <section class="pt-6 pb-8 md:py-16 bg-white border-b border-slate-100 overflow-hidden relative">
         <div class="marquee-mask w-full">
             <div class="flex animate-marquee whitespace-nowrap items-center w-max gap-12 md:gap-20 px-10">
                 <div class="flex items-center gap-12 md:gap-20">
-                    <img src="https://i.imgur.com/MjJTKti.png" alt="Nationwide Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/SJQzwRU.png" alt="Progressive Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/JNB2wDG.png" alt="Travelers Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/9ZWQsAS.png" alt="National General Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/RexcFEo.png" alt="Alamance Farmers Mutual Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/rHIo4r5.jpg" alt="Foremost Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/MjJTKti.png" alt="Nationwide Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/SJQzwRU.png" alt="Progressive Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/JNB2wDG.png" alt="Travelers Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/9ZWQsAS.png" alt="National General Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/RexcFEo.png" alt="Alamance Farmers Mutual Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/rHIo4r5.jpg" alt="Foremost Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
                 </div>
                 <!-- Duplicate Set for seamless scroll -->
                 <div class="flex items-center gap-12 md:gap-20">
-                    <img src="https://i.imgur.com/MjJTKti.png" alt="Nationwide Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/SJQzwRU.png" alt="Progressive Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/JNB2wDG.png" alt="Travelers Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/9ZWQsAS.png" alt="National General Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/RexcFEo.png" alt="Alamance Farmers Mutual Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
-                    <img src="https://i.imgur.com/rHIo4r5.jpg" alt="Foremost Insurance NC carrier logo" class="h-12 md:h-16 w-auto object-contain hover:scale-110 transition-transform" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/MjJTKti.png" alt="Nationwide Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/SJQzwRU.png" alt="Progressive Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/JNB2wDG.png" alt="Travelers Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/9ZWQsAS.png" alt="National General Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/RexcFEo.png" alt="Alamance Farmers Mutual Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
+                    <img src="https://i.imgur.com/rHIo4r5.jpg" alt="Foremost Insurance NC carrier logo" class="carrier-logo h-12 md:h-16 w-auto object-contain" loading="lazy" decoding="async">
                 </div>
             </div>
         </div>
@@ -871,12 +881,17 @@
     <section class="py-10 sm:py-12 md:py-16 bg-slate-50 relative overflow-hidden">
         <div class="absolute right-0 top-0 w-1/3 h-full bg-white skew-x-12 opacity-50 pointer-events-none"></div>
         <div class="max-w-5xl mx-auto px-4 relative z-10">
-            <div class="text-center mb-8 sm:mb-10 reveal">
-                <span class="text-primary-600 font-bold tracking-widest uppercase text-xs mb-3 block">Why Choose Independent?</span>
-                <h2 class="text-3xl sm:text-4xl md:text-5xl font-display font-black text-slate-900 mb-4">The "Single-Quote" Trap</h2>
-                <p class="text-base sm:text-lg text-slate-600 max-w-2xl mx-auto">Most agents work for <i>one</i> company and can only offer <i>one</i> price. We work for <u>you</u>.</p>
+            <div class="grid md:grid-cols-2 gap-8 items-center mb-8 sm:mb-10 reveal">
+                <div class="text-center md:text-left">
+                    <span class="text-primary-600 font-bold tracking-widest uppercase text-xs mb-3 block">Why Choose Independent?</span>
+                    <h2 class="text-3xl sm:text-4xl md:text-5xl font-display font-black text-slate-900 mb-4">The "Single-Quote" Trap</h2>
+                    <p class="text-base sm:text-lg text-slate-600">Most agents work for <i>one</i> company and can only offer <i>one</i> price. We work for <u>you</u>.</p>
+                </div>
+                <div class="hidden md:block">
+                    <img src="https://images.unsplash.com/photo-1560518883-ce09059eeffa?auto=format&fit=crop&w=800&q=80" alt="Happy North Carolina family standing proudly in front of their protected home" class="w-full h-56 lg:h-64 object-cover rounded-2xl md:rounded-3xl shadow-lg" loading="lazy" decoding="async">
+                </div>
             </div>
-            
+
             <div class="bg-white rounded-2xl md:rounded-[2.5rem] shadow-2xl overflow-hidden border border-slate-200 reveal" style="box-shadow: 0 8px 40px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.04);">
                 <div class="grid grid-cols-12 text-center">
                     <!-- HEADER ROW -->
@@ -946,6 +961,11 @@
                 <p class="text-base sm:text-lg text-slate-600 max-w-2xl mx-auto">The #1 reason people stay with expensive carriers? They think switching is hard. <strong>It's not.</strong></p>
             </div>
 
+            <!-- Lifestyle image — happy family at home -->
+            <div class="max-w-2xl mx-auto mb-10 reveal">
+                <img src="https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=900&q=80" alt="Insurance agent reviewing coverage options with happy North Carolina couple" class="w-full h-44 sm:h-52 md:h-60 object-cover rounded-2xl md:rounded-3xl shadow-lg" loading="lazy" decoding="async">
+            </div>
+
             <div class="grid md:grid-cols-2 gap-8 items-center max-w-4xl mx-auto">
                 <!-- Old Way -->
                 <div class="bg-red-50 border-2 border-red-100 rounded-3xl p-6 sm:p-8 text-center relative">
@@ -1000,22 +1020,30 @@
                 <p class="text-slate-500 max-w-2xl mx-auto">Tailored protection for your lifestyle in Elkin & beyond.</p>
             </div>
             <div class="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
-                <a href="get-quote.html" class="group p-5 sm:p-6 md:p-10 bg-white rounded-2xl md:rounded-[2.5rem] shadow-xl border border-slate-100 hover:border-primary-500 hover:shadow-2xl transition-all reveal hover:-translate-y-2 relative overflow-hidden">
+                <!-- Auto Insurance Card -->
+                <a href="get-quote.html" class="group bg-white rounded-2xl md:rounded-[2.5rem] shadow-xl border border-slate-100 hover:border-primary-500 hover:shadow-2xl transition-all reveal hover:-translate-y-2 relative overflow-hidden">
                     <span class="absolute top-3 right-3 md:top-5 md:right-5 bg-yellow-400 text-slate-900 text-[10px] md:text-xs font-black px-2 py-1 rounded-full uppercase tracking-wider z-20 shadow-sm">Most Popular</span>
-                    <div class="absolute top-0 right-0 w-32 h-32 bg-primary-100 rounded-bl-[100px] -mr-10 -mt-10 transition-transform group-hover:scale-110"></div>
-                    <div class="relative z-10">
-                        <div class="w-16 h-16 bg-primary-600 rounded-2xl flex items-center justify-center text-white text-2xl mb-8 shadow-lg shadow-primary-500/30"><i class="fas fa-car"></i></div>
+                    <div class="relative h-36 sm:h-40 md:h-48 overflow-hidden">
+                        <img src="https://i.imgur.com/KRA41MH.jpeg" alt="White sedan parked in a residential NC neighborhood driveway" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" loading="lazy" decoding="async">
+                        <div class="absolute inset-0 bg-gradient-to-t from-white via-transparent to-transparent"></div>
+                    </div>
+                    <div class="relative z-10 px-5 pb-5 sm:px-6 sm:pb-6 md:px-10 md:pb-10">
+                        <div class="w-14 h-14 md:w-16 md:h-16 bg-primary-600 rounded-2xl flex items-center justify-center text-white text-xl md:text-2xl mb-5 md:mb-6 shadow-lg shadow-primary-500/30 -mt-8 md:-mt-10 border-4 border-white"><i class="fas fa-car"></i></div>
                         <h3 class="text-2xl font-bold mb-4">Auto Insurance</h3>
                         <p class="text-slate-600 mb-8 leading-relaxed">Compare rates on liability, collision, and comprehensive. Experts in <strong>NC Rate Bureau</strong> rules & available discounts.</p>
                         <span class="font-bold text-primary-600 flex items-center gap-2 group-hover:gap-4 transition-all">Start Auto Quote <i class="fas fa-arrow-right"></i></span>
                     </div>
                 </a>
 
-                <a href="get-quote.html" class="group p-5 sm:p-6 md:p-10 bg-white rounded-2xl md:rounded-[2.5rem] shadow-xl border border-slate-100 hover:border-accent-500 hover:shadow-2xl transition-all reveal delay-100 hover:-translate-y-2 relative overflow-hidden">
+                <!-- Home Insurance Card -->
+                <a href="get-quote.html" class="group bg-white rounded-2xl md:rounded-[2.5rem] shadow-xl border border-slate-100 hover:border-accent-500 hover:shadow-2xl transition-all reveal delay-100 hover:-translate-y-2 relative overflow-hidden">
                     <span class="absolute top-3 right-3 md:top-5 md:right-5 bg-yellow-400 text-slate-900 text-[10px] md:text-xs font-black px-2 py-1 rounded-full uppercase tracking-wider z-20 shadow-sm">Most Popular</span>
-                    <div class="absolute top-0 right-0 w-32 h-32 bg-accent-100 rounded-bl-[100px] -mr-10 -mt-10 transition-transform group-hover:scale-110"></div>
-                    <div class="relative z-10">
-                        <div class="w-16 h-16 bg-accent-500 rounded-2xl flex items-center justify-center text-white text-2xl mb-8 shadow-lg shadow-accent-500/30"><i class="fas fa-house"></i></div>
+                    <div class="relative h-36 sm:h-40 md:h-48 overflow-hidden">
+                        <img src="https://i.imgur.com/8GS5o3C.jpeg" alt="Two-story brick and siding home with front porch and green lawn in North Carolina" class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" loading="lazy" decoding="async">
+                        <div class="absolute inset-0 bg-gradient-to-t from-white via-transparent to-transparent"></div>
+                    </div>
+                    <div class="relative z-10 px-5 pb-5 sm:px-6 sm:pb-6 md:px-10 md:pb-10">
+                        <div class="w-14 h-14 md:w-16 md:h-16 bg-accent-500 rounded-2xl flex items-center justify-center text-white text-xl md:text-2xl mb-5 md:mb-6 shadow-lg shadow-accent-500/30 -mt-8 md:-mt-10 border-4 border-white"><i class="fas fa-house"></i></div>
                         <h3 class="text-2xl font-bold mb-4">Home Insurance</h3>
                         <p class="text-slate-600 mb-8 leading-relaxed">Protect your biggest investment. Specialists in <strong>NC Coastal vs. Inland</strong> wind/hail coverage.</p>
                         <span class="font-bold text-accent-600 flex items-center gap-2 group-hover:gap-4 transition-all">Start Home Quote <i class="fas fa-arrow-right"></i></span>
@@ -1231,7 +1259,7 @@
         <div class="max-w-7xl mx-auto px-4">
             <div class="text-center mb-8 sm:mb-10 md:mb-12 reveal">
                 <h2 class="text-3xl sm:text-4xl md:text-5xl font-display font-black text-slate-900 mb-4 sm:mb-6">Explore Your Coverage</h2>
-                <p class="text-base sm:text-lg text-slate-600 max-w-2xl mx-auto">Tap the gold dots to see exactly what is protected (and what isn't).</p>
+                <p class="text-base sm:text-lg text-slate-600 max-w-2xl mx-auto">Tap the icons on the image to see exactly what's protected (and what isn't).</p>
             </div>
             
             <div id="blCoverageWidget" class="reveal"></div>
@@ -1323,30 +1351,42 @@
             .bl-hotspot {
                 position: absolute;
                 transform: translate(-50%, -50%);
-                width: 40px; height: 40px;
+                width: 44px; height: 44px;
                 border-radius: 999px;
-                border: 2px solid #fff;
-                background: rgba(255,255,255,0.2);
+                border: 2.5px solid #fff;
+                background: rgba(30, 58, 138, 0.85);
                 backdrop-filter: blur(4px);
-                box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+                box-shadow: 0 4px 14px rgba(0,0,0,0.35), 0 0 0 0 rgba(251, 191, 36, 0.5);
                 display: grid;
                 place-items: center;
                 cursor: pointer;
-                transition: transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+                transition: all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+                animation: bl-pulse 2.5s infinite;
             }
-            .bl-hotspot:hover { transform: translate(-50%, -50%) scale(1.2); }
-            
-            .bl-hotspot::after {
-                content: "";
-                width: 16px; height: 16px; border-radius: 999px;
+            .bl-hotspot i {
+                color: #fbbf24;
+                font-size: 16px;
+                filter: drop-shadow(0 1px 2px rgba(0,0,0,0.3));
+                transition: color 0.2s;
+            }
+            .bl-hotspot:hover {
+                transform: translate(-50%, -50%) scale(1.2);
                 background: var(--bl-accent);
-                box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7);
-                animation: bl-pulse 2s infinite;
+                border-color: #fff;
+                box-shadow: 0 6px 20px rgba(251, 191, 36, 0.5);
             }
+            .bl-hotspot:hover i { color: #1e3a8a; }
+            .bl-hotspot-active {
+                background: var(--bl-accent) !important;
+                box-shadow: 0 6px 20px rgba(251, 191, 36, 0.5) !important;
+                animation: none !important;
+                transform: translate(-50%, -50%) scale(1.15);
+            }
+            .bl-hotspot-active i { color: #1e3a8a !important; }
             @keyframes bl-pulse {
-                0% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0.7); }
-                70% { box-shadow: 0 0 0 10px rgba(251, 191, 36, 0); }
-                100% { box-shadow: 0 0 0 0 rgba(251, 191, 36, 0); }
+                0% { box-shadow: 0 4px 14px rgba(0,0,0,0.35), 0 0 0 0 rgba(251, 191, 36, 0.5); }
+                70% { box-shadow: 0 4px 14px rgba(0,0,0,0.35), 0 0 0 12px rgba(251, 191, 36, 0); }
+                100% { box-shadow: 0 4px 14px rgba(0,0,0,0.35), 0 0 0 0 rgba(251, 191, 36, 0); }
             }
 
             .bl-panel {
@@ -1443,8 +1483,8 @@
                 .bl-tab { flex: 1; text-align: center; }
             }
             @media (min-width: 769px) {
-                .bl-hotspot { width: 32px; height: 32px; }
-                .bl-hotspot::after { width: 12px; height: 12px; }
+                .bl-hotspot { width: 48px; height: 48px; }
+                .bl-hotspot i { font-size: 18px; }
             }
         </style>
 
@@ -1460,39 +1500,42 @@
                 const DATA = {
                     home: {
                         label: "Home",
+                        icon: "fas fa-home",
                         bgClass: "bg-home",
                         title: "Home Insurance",
-                        subtitle: "Tap a gold dot to see what's covered.",
+                        subtitle: "Tap an icon to see what's covered.",
                         hotspots: [
-                            { x: 50, y: 45, title: "Dwelling Coverage", text: "Pays to rebuild your home if damaged by fire, wind, or hail. We calculate true replacement cost, not market value.", cta: "Check My Limit" },
-                            { x: 25, y: 65, title: "Liability Protection", text: "Protects your savings if a guest is injured on your property or your dog bites someone.", cta: "Review Liability" },
-                            { x: 75, y: 30, title: "Roof & Storms", text: "NC storms are tough. We check if your policy covers 'Replacement Cost' for your roof, not just depreciated value.", cta: "Roof Check" },
-                            { x: 85, y: 55, title: "Other Structures", text: "Covers detached garages, fences, sheds, and driveways. Usually calculated as 10% of your dwelling coverage automatically.", cta: "Check Detached" },
-                            { x: 40, y: 65, title: "Personal Property", text: "Covers your stuff (furniture, clothes, electronics). We recommend 'Replacement Cost' so you get new items, not garage sale value.", cta: "Protect Stuff" }
+                            { x: 50, y: 45, icon: "fas fa-home", title: "Dwelling Coverage", text: "Pays to rebuild your home if damaged by fire, wind, or hail. We calculate true replacement cost, not market value.", cta: "Check My Limit" },
+                            { x: 25, y: 65, icon: "fas fa-shield-alt", title: "Liability Protection", text: "Protects your savings if a guest is injured on your property or your dog bites someone.", cta: "Review Liability" },
+                            { x: 75, y: 30, icon: "fas fa-cloud-showers-heavy", title: "Roof & Storms", text: "NC storms are tough. We check if your policy covers 'Replacement Cost' for your roof, not just depreciated value.", cta: "Roof Check" },
+                            { x: 85, y: 55, icon: "fas fa-warehouse", title: "Other Structures", text: "Covers detached garages, fences, sheds, and driveways. Usually calculated as 10% of your dwelling coverage automatically.", cta: "Check Detached" },
+                            { x: 40, y: 65, icon: "fas fa-couch", title: "Personal Property", text: "Covers your stuff (furniture, clothes, electronics). We recommend 'Replacement Cost' so you get new items, not garage sale value.", cta: "Protect Stuff" }
                         ]
                     },
                     auto: {
                         label: "Auto",
+                        icon: "fas fa-car",
                         bgClass: "bg-auto",
                         title: "Auto Insurance",
-                        subtitle: "Understand your coverage beyond the price.",
+                        subtitle: "Tap an icon to understand your coverage.",
                         hotspots: [
-                            { x: 30, y: 55, title: "Liability Limits", text: "Pays for the OTHER person's medical bills if you crash. State minimums are often too low to protect your assets.", cta: "Check Limits" },
-                            { x: 65, y: 60, title: "Collision", text: "Fixes YOUR car if you hit something. Choosing a $500 vs $1000 deductible affects your rate significantly.", cta: "Compare Deductibles" },
-                            { x: 70, y: 35, title: "Comprehensive (Deer)", text: "Crucial for NC drivers. Covers deer hits, falling trees, glass, and theft. Usually affordable to add.", cta: "Add Deer Coverage" },
-                            { x: 20, y: 40, title: "Rental Reimbursement", text: "Pays for a rental car ($30-$50/day) while yours is being repaired after a covered claim. Don't get stuck without a ride.", cta: "Add Rental" },
-                            { x: 85, y: 70, title: "Towing & Labor", text: "Pays for tow trucks, jump starts, and lockout services. Often much cheaper than third-party auto clubs.", cta: "Add Roadside" }
+                            { x: 30, y: 55, icon: "fas fa-user-shield", title: "Liability Limits", text: "Pays for the OTHER person's medical bills if you crash. State minimums are often too low to protect your assets.", cta: "Check Limits" },
+                            { x: 65, y: 60, icon: "fas fa-car-crash", title: "Collision", text: "Fixes YOUR car if you hit something. Choosing a $500 vs $1000 deductible affects your rate significantly.", cta: "Compare Deductibles" },
+                            { x: 70, y: 35, icon: "fas fa-tree", title: "Comprehensive (Deer)", text: "Crucial for NC drivers. Covers deer hits, falling trees, glass, and theft. Usually affordable to add.", cta: "Add Deer Coverage" },
+                            { x: 20, y: 40, icon: "fas fa-key", title: "Rental Reimbursement", text: "Pays for a rental car ($30-$50/day) while yours is being repaired after a covered claim. Don't get stuck without a ride.", cta: "Add Rental" },
+                            { x: 85, y: 70, icon: "fas fa-truck-pickup", title: "Towing & Labor", text: "Pays for tow trucks, jump starts, and lockout services. Often much cheaper than third-party auto clubs.", cta: "Add Roadside" }
                         ]
                     },
                     business: {
                         label: "Business",
+                        icon: "fas fa-briefcase",
                         bgClass: "bg-business",
                         title: "Business Owners",
-                        subtitle: "Protecting your livelihood in Elkin.",
+                        subtitle: "Tap an icon to explore your protection.",
                         hotspots: [
-                            { x: 35, y: 60, title: "General Liability", text: "The foundation. Protects against slip-and-fall lawsuits or damage you cause to client property.", cta: "Get Liability Quote" },
-                            { x: 60, y: 50, title: "Property & Tools", text: "Covers your inventory, equipment, and building. Don't let a fire wipe out your hard work.", cta: "Protect Assets" },
-                            { x: 75, y: 25, title: "Cyber Coverage", text: "Essential if you take credit cards or store client data. Protects against breaches and hacks.", cta: "Ask About Cyber" }
+                            { x: 35, y: 60, icon: "fas fa-balance-scale", title: "General Liability", text: "The foundation. Protects against slip-and-fall lawsuits or damage you cause to client property.", cta: "Get Liability Quote" },
+                            { x: 60, y: 50, icon: "fas fa-tools", title: "Property & Tools", text: "Covers your inventory, equipment, and building. Don't let a fire wipe out your hard work.", cta: "Protect Assets" },
+                            { x: 75, y: 25, icon: "fas fa-laptop-code", title: "Cyber Coverage", text: "Essential if you take credit cards or store client data. Protects against breaches and hacks.", cta: "Ask About Cyber" }
                         ]
                     }
                 };
@@ -1506,11 +1549,13 @@
                     const displayData = selectedHotspot || { title: topic.title, text: topic.subtitle, cta: "Start Quote" };
                     
                     let hotspotsHtml = topic.hotspots.map((h, i) => `
-                        <button class="bl-hotspot" style="left:${h.x}%; top:${h.y}%;" onclick="window.selectHotspot(${i})" aria-label="${h.title}"></button>
+                        <button class="bl-hotspot${selectedHotspot === h ? ' bl-hotspot-active' : ''}" style="left:${h.x}%; top:${h.y}%;" onclick="window.selectHotspot(${i})" aria-label="${h.title}">
+                            <i class="${h.icon}"></i>
+                        </button>
                     `).join('');
 
                     let tabsHtml = Object.keys(DATA).map(key => `
-                        <button class="bl-tab" aria-selected="${activeTab === key}" onclick="window.selectTab('${key}')">${DATA[key].label}</button>
+                        <button class="bl-tab" aria-selected="${activeTab === key}" onclick="window.selectTab('${key}')"><i class="${DATA[key].icon}" style="margin-right:6px;"></i>${DATA[key].label}</button>
                     `).join('');
 
                     mount.innerHTML = `


### PR DESCRIPTION
## Summary
- **Hero background**: Replaced with custom Pilot Mountain sunset photo (desktop + mobile)
- **Service cards**: Added custom NC auto (white Camry) and home (brick two-story) image headers with overlapping icons
- **Interior sections**: Added lifestyle images to Why Choose Independent (split layout) and Switching is Painless sections
- **Coverage Explorer**: Upgraded gold dots to interactive FontAwesome icon hotspots with active state highlighting, added icons to tabs
- **Carrier trust bar**: Added grayscale-to-color hover effect on carrier logos

## Test plan
- [ ] Verify Pilot Mountain hero displays on desktop, tablet, and mobile
- [ ] Verify Auto and Home card images load correctly
- [ ] Test Coverage Explorer icon interactions (Home/Auto/Business tabs, hotspot click highlights)
- [ ] Hover over carrier logos to confirm grayscale-to-color transition
- [ ] Check all viewports (mobile 375px, tablet 768px, desktop 1280px+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)