### PR TITLE
Update hero to North Carolina Independent Insurance Agency

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
                     </div>
                 </div>
             </div>
-            <h1 class="mobile-hero-h1">Elkin, NC Independent Insurance Agency</h1>
+            <h1 class="mobile-hero-h1">North Carolina Independent Insurance Agency</h1>
             <h2 class="hero-headline">One Call.<br><span class="highlight">Multiple Quotes.</span></h2>
             <p class="hero-sub">We make top carriers <strong>compete for your rate.</strong> You pick the winner.</p>
             <p class="carrier-mention"><span>Progressive</span> · <span>Travelers</span> · <span>Nationwide</span> · <span>National General</span> &amp; more</p>
@@ -682,7 +682,7 @@
                         <span class="text-white/80 md:text-white md:opacity-90 ml-0.5 md:ml-1"><span class="md:hidden">4.9 &middot; Elkin, NC</span><span class="hidden md:inline">Verified Local Agency</span></span>
                     </div>
 
-                    <h1 class="text-sm sm:text-base font-semibold uppercase tracking-[0.2em] text-blue-200 mb-3">Elkin, NC Independent Insurance Agency</h1>
+                    <h1 class="text-sm sm:text-base font-semibold uppercase tracking-[0.2em] text-blue-200 mb-3">North Carolina Independent Insurance Agency</h1>
 
                     <!-- HEADLINE: Dominates mobile screen, full version on desktop -->
                     <h2 class="font-display font-black tracking-tight drop-shadow-2xl mb-3 md:mb-6">


### PR DESCRIPTION
## Summary
- Changed hero subtitle from "Elkin, NC Independent Insurance Agency" to "North Carolina Independent Insurance Agency" on both desktop and mobile
- Broadens geographic appeal for prospects across NC, not just Elkin

## Test plan
- [ ] Verify desktop hero shows "NORTH CAROLINA INDEPENDENT INSURANCE AGENCY"
- [ ] Verify mobile hero shows the same updated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)