### PR TITLE
Add Pilot Mountain hero to all subpages

### DIFF
--- a/areas-we-serve.html
+++ b/areas-we-serve.html
@@ -48,7 +48,7 @@
         }
         
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #4f46e5, #7c3aed);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
         
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/auto-center/carriers/alamance-north-carolina.html
+++ b/auto-center/carriers/alamance-north-carolina.html
@@ -71,7 +71,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #0f172a 0%, #1e3a8a 50%, #3730a3 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/auto-center/carriers/dairyland-north-carolina.html
+++ b/auto-center/carriers/dairyland-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 50%, #a78bfa 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/auto-center/carriers/foremost-north-carolina.html
+++ b/auto-center/carriers/foremost-north-carolina.html
@@ -72,7 +72,7 @@
         
         /* F-Pattern Hero with Foremost Branding */
         .f-hero {
-            background: linear-gradient(135deg, #7f1d1d 0%, #dc2626 50%, #ef4444 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/auto-center/carriers/hagerty-north-carolina.html
+++ b/auto-center/carriers/hagerty-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero with Hagerty Classic Branding */
         .f-hero {
-            background: linear-gradient(135deg, #1a1a1a 0%, #8b1a1a 50%, #d4af37 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/auto-center/carriers/national-general-north-carolina.html
+++ b/auto-center/carriers/national-general-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #003366 0%, #004488 50%, #0055aa 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/auto-center/carriers/nationwide-north-carolina.html
+++ b/auto-center/carriers/nationwide-north-carolina.html
@@ -72,7 +72,7 @@
         
         /* F-Pattern Hero with Nationwide Branding */
         .f-hero {
-            background: linear-gradient(135deg, #0047ab 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/auto-center/carriers/nc-grange-north-carolina.html
+++ b/auto-center/carriers/nc-grange-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #2d5016 0%, #4a7c2e 50%, #5a8d3a 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/auto-center/carriers/progressive-north-carolina.html
+++ b/auto-center/carriers/progressive-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero with Progressive Branding */
         .f-hero {
-            background: linear-gradient(135deg, #00539C 0%, #4A90E2 50%, #0088ff 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/auto-center/carriers/travelers-north-carolina.html
+++ b/auto-center/carriers/travelers-north-carolina.html
@@ -73,7 +73,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #d71e2b 0%, #b5161f 50%, #8b0000 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/auto-center/claims-process-guide.html
+++ b/auto-center/claims-process-guide.html
@@ -36,7 +36,7 @@
     <style>
         /* Custom styles */
         .hero-bg {
-            background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://images.unsplash.com/photo-1558618644-fbd6c52ac0da?ixlib=rb-4.0.3');
+            background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
         }

--- a/auto-center/coverage-comparison.html
+++ b/auto-center/coverage-comparison.html
@@ -36,7 +36,7 @@
     <style>
         /* Custom styles */
         .hero-bg {
-            background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?ixlib=rb-4.0.3');
+            background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
         }

--- a/auto-center/first-time-buyers-guide.html
+++ b/auto-center/first-time-buyers-guide.html
@@ -36,7 +36,7 @@
     <style>
         /* Custom styles */
         .hero-bg {
-            background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?ixlib=rb-4.0.3');
+            background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
         }

--- a/auto-center/index.html
+++ b/auto-center/index.html
@@ -68,7 +68,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #2563eb, #1e3a8a);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
 
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/auto-center/understanding-your-policy.html
+++ b/auto-center/understanding-your-policy.html
@@ -36,7 +36,7 @@
     <style>
         /* Custom styles */
         .hero-bg {
-            background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?ixlib=rb-4.0.3');
+            background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
         }

--- a/auto-insurance.html
+++ b/auto-insurance.html
@@ -167,7 +167,7 @@
         }
         
         .hero-bg {
-            background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://github.com/BillLayne/bill-layne-images/blob/main/logos/Car%20Insurance.png?raw=true');
+            background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
         }

--- a/blog.html
+++ b/blog.html
@@ -451,7 +451,7 @@
 </header>
 
     <!-- Hero Section -->
-    <section class="relative bg-blue-600 text-white pt-32 pb-20" style="background-image: url('https://github.com/BillLayne/bill-layne-images/blob/main/logos/blog%20hero.png?raw=true'); background-size: cover; background-position: center; background-repeat: no-repeat;">
+    <section class="relative bg-blue-600 text-white pt-32 pb-20" style="background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url('https://i.imgur.com/DDGMV4c.png'); background-size: cover; background-position: center; background-repeat: no-repeat;">
         <div class="absolute inset-0 bg-black opacity-40"></div>
         <div class="container relative mx-auto px-4">
             <div class="max-w-4xl mx-auto text-center">

--- a/blog/blogs/elkin-nc-car-insurance-costs-2026.html
+++ b/blog/blogs/elkin-nc-car-insurance-costs-2026.html
@@ -57,7 +57,7 @@
         .trust-badge { display: inline-flex; align-items: center; gap: 8px; background: #f1f5f9; padding: 8px 16px; border-radius: 24px; font-size: 0.875rem; font-weight: 600; color: #475569; }
         html { scroll-behavior: smooth; }
         #progress-bar { position: fixed; top: 56px; left: 0; height: 4px; background: linear-gradient(90deg, #1e40af 0%, #3b82f6 100%); width: 0%; z-index: 50; transition: width 0.1s ease-out; }
-        .hero-bg { background-image: linear-gradient(rgba(30, 64, 175, 0.85), rgba(30, 58, 138, 0.9)), url('https://i.imgur.com/ROR2zO3.png'); background-size: cover; background-position: center; }
+        .hero-bg { background-image: linear-gradient(rgba(15, 23, 42, 0.6), rgba(15, 23, 42, 0.7)), url("https://i.imgur.com/DDGMV4c.png"); background-size: cover; background-position: center; }
         .comparison-row:hover { background-color: #f8fafc; transform: translateX(4px); transition: all 0.2s ease; }
     </style>
     <link rel="stylesheet" href="../../css/mobile-dock.css">

--- a/blog/index.html
+++ b/blog/index.html
@@ -97,7 +97,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/alamance.html
+++ b/carriers/alamance.html
@@ -75,9 +75,7 @@
         
         /* F-Pattern Hero with Alamance Farmers Mutual Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(30, 58, 138, 0.95) 0%, rgba(30, 41, 86, 0.90) 50%, rgba(251, 191, 36, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1625246333195-78d9c38ad449?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/dairyland.html
+++ b/carriers/dairyland.html
@@ -73,9 +73,7 @@
         
         /* F-Pattern Hero with Dairyland Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(0, 90, 156, 0.95) 0%, rgba(0, 166, 160, 0.90) 50%, rgba(37, 99, 235, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/foremost.html
+++ b/carriers/foremost.html
@@ -75,8 +75,8 @@
         /* F-Pattern Hero with Foremost Blue Branding */
         .f-hero {
             background-image: 
-                linear-gradient(135deg, rgba(0, 58, 112, 0.85) 0%, rgba(0, 102, 204, 0.8) 50%, rgba(74, 144, 226, 0.75) 100%),
-                url('https://github.com/BillLayne/bill-layne-images/blob/main/logos/foremost%20background%20image.webp?raw=true');
+                linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/carriers/hagerty.html
+++ b/carriers/hagerty.html
@@ -73,9 +73,7 @@
         
         /* F-Pattern Hero with Hagerty Classic Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(26, 26, 26, 0.95) 0%, rgba(139, 26, 26, 0.90) 50%, rgba(212, 175, 55, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1583121274602-3e2820c69888?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/national-general.html
+++ b/carriers/national-general.html
@@ -75,9 +75,7 @@
         
         /* F-Pattern Hero with National General Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(0, 82, 204, 0.95) 0%, rgba(0, 61, 153, 0.90) 50%, rgba(239, 68, 68, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1449965408869-eaa3f722e40d?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/nationwide.html
+++ b/carriers/nationwide.html
@@ -72,9 +72,7 @@
         
         /* F-Pattern Hero with Nationwide Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(0, 71, 171, 0.85) 0%, rgba(37, 99, 235, 0.85) 50%, rgba(59, 130, 246, 0.85) 100%),
-                url('https://github.com/BillLayne/bill-layne-images/blob/main/logos/nationwide%20hero%20background%20logo.webp?raw=true') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/nc-grange.html
+++ b/carriers/nc-grange.html
@@ -75,9 +75,7 @@
         
         /* F-Pattern Hero with NC Grange Mutual Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(45, 80, 22, 0.95) 0%, rgba(26, 48, 9, 0.90) 50%, rgba(212, 175, 55, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1500382017468-9049fed747ef?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/carriers/progressive.html
+++ b/carriers/progressive.html
@@ -74,8 +74,8 @@
         /* F-Pattern Hero with Progressive Branding */
         .f-hero {
             background-image: 
-                linear-gradient(135deg, rgba(0, 83, 156, 0.85), rgba(74, 144, 226, 0.85), rgba(0, 136, 255, 0.85)),
-                url('https://github.com/BillLayne/bill-layne-images/blob/main/logos/progressive%20background%20hero.webp?raw=true');
+                linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             background-repeat: no-repeat;

--- a/carriers/travelers.html
+++ b/carriers/travelers.html
@@ -74,9 +74,7 @@
         
         /* F-Pattern Hero with Travelers Branding */
         .f-hero {
-            background: 
-                linear-gradient(135deg, rgba(210, 38, 48, 0.95) 0%, rgba(184, 30, 39, 0.90) 50%, rgba(37, 99, 235, 0.85) 100%),
-                url('https://images.unsplash.com/photo-1560518883-ce09059eeffa?ixlib=rb-4.0.3') center/cover no-repeat;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/claims-center/carrier-contacts.html
+++ b/claims-center/carrier-contacts.html
@@ -70,7 +70,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 180px;

--- a/claims-center/index.html
+++ b/claims-center/index.html
@@ -55,7 +55,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #4f46e5, #312e81);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
         
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/contact-us.html
+++ b/contact-us.html
@@ -125,7 +125,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #2563eb, #4f46e5);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
         
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/espanol/index.html
+++ b/espanol/index.html
@@ -157,7 +157,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #059669, #047857);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
 
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/home-insurance/coverage-calculator.html
+++ b/home-insurance/coverage-calculator.html
@@ -68,7 +68,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 140px;

--- a/home-insurance/deductible-analyzer.html
+++ b/home-insurance/deductible-analyzer.html
@@ -68,7 +68,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 140px;

--- a/home-insurance/discount-checker.html
+++ b/home-insurance/discount-checker.html
@@ -68,7 +68,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 140px;

--- a/home-insurance/home-inventory-worksheet.html
+++ b/home-insurance/home-inventory-worksheet.html
@@ -68,7 +68,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 140px;

--- a/home-insurance/index.html
+++ b/home-insurance/index.html
@@ -55,7 +55,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #0d9488, #0f172a);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
         
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/homeowners-insurance.html
+++ b/homeowners-insurance.html
@@ -350,8 +350,8 @@
     <!-- Hero Section -->
     <section class="relative pt-20 pb-24 overflow-hidden">
         <div class="absolute inset-0">
-            <div class="w-full h-full bg-gradient-to-br from-blue-900 to-indigo-900"></div>
-            <div class="absolute inset-0 bg-gradient-to-br from-blue-900/90 to-purple-900/90"></div>
+            <img src="https://i.imgur.com/DDGMV4c.png" alt="Pilot Mountain at sunset" class="w-full h-full object-cover">
+            <div class="absolute inset-0 bg-gradient-to-br from-slate-900/70 via-blue-900/65 to-indigo-900/70"></div>
         </div>
         <div class="relative container mx-auto px-4 py-20 text-center text-white">
             <h1 class="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 animate-fadeInUp">

--- a/resources/auto-coverage-analyzer.html
+++ b/resources/auto-coverage-analyzer.html
@@ -70,7 +70,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/resources/claims-process-guide.html
+++ b/resources/claims-process-guide.html
@@ -70,7 +70,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 50%, #3b82f6 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/resources/homeowners-estimator.html
+++ b/resources/homeowners-estimator.html
@@ -70,7 +70,7 @@
         
         /* F-Pattern Hero */
         .f-hero {
-            background: linear-gradient(135deg, #059669 0%, #10b981 50%, #34d399 100%);
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 58, 138, 0.65)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
             overflow: hidden;
             padding-top: 120px;

--- a/resources/index.html
+++ b/resources/index.html
@@ -40,7 +40,7 @@
         }
         
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #0d9488, #2563eb);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
         }
         
         .reveal { opacity: 0; transform: translateY(20px); transition: all 0.8s cubic-bezier(0.5, 0, 0, 1); }

--- a/save-in-dobson-nc/index.html
+++ b/save-in-dobson-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Dobson+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/save-in-elkin-nc/index.html
+++ b/save-in-elkin-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Elkin+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/save-in-jonesville-nc/index.html
+++ b/save-in-jonesville-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Jonesville+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/save-in-mount-airy-nc/index.html
+++ b/save-in-mount-airy-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Mount+Airy+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/save-in-wilkesboro-nc/index.html
+++ b/save-in-wilkesboro-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Wilkesboro+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/save-in-yadkinville-nc/index.html
+++ b/save-in-yadkinville-nc/index.html
@@ -77,7 +77,8 @@
         
         /* Hero Section */
         .f-hero {
-            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.95) 0%, rgba(30, 58, 138, 0.98) 100%), url('https://placehold.co/1920x1080/334155/64748B?text=Yadkinville+NC');
+            background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.75), rgba(30, 58, 138, 0.7)),
+                url("https://i.imgur.com/DDGMV4c.png");
             background-size: cover;
             background-position: center;
             position: relative;

--- a/service-center.html
+++ b/service-center.html
@@ -157,7 +157,7 @@
             box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
         }
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #1e40af, #020617);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
         }
         .bg-vivid-hero::before {

--- a/videos/index.html
+++ b/videos/index.html
@@ -182,7 +182,7 @@
         }
 
         .bg-vivid-hero {
-            background: radial-gradient(circle at top right, #1e40af, #020617);
+            background: linear-gradient(rgba(15, 23, 42, 0.65), rgba(30, 58, 138, 0.6)), url("https://i.imgur.com/DDGMV4c.png") center/cover no-repeat;
             position: relative;
         }
         .bg-vivid-hero::before {


### PR DESCRIPTION
## Summary
- Adds the custom Pilot Mountain sunset photo as the hero background across all 50 subpages for consistent brand identity
- Updates three CSS hero patterns (`.hero-bg`, `.f-hero`, `.bg-vivid-hero`) with the imgur-hosted image and gradient overlays
- Blog post-specific hero illustrations (Halloween, bootlegger, etc.) are preserved unchanged

## Test plan
- [ ] Verify hero backgrounds display correctly on carrier pages
- [ ] Verify hero backgrounds on auto-center, home-insurance, and resource pages
- [ ] Verify save-in-* location pages show Pilot Mountain hero
- [ ] Check mobile and tablet responsiveness of hero sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)