### PR TITLE
Fix scroll reveal blank space on 21 pages

### DIFF
--- a/auto-center/carriers/alamance-north-carolina.html
+++ b/auto-center/carriers/alamance-north-carolina.html
@@ -877,7 +877,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/dairyland-north-carolina.html
+++ b/auto-center/carriers/dairyland-north-carolina.html
@@ -1027,7 +1027,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/foremost-north-carolina.html
+++ b/auto-center/carriers/foremost-north-carolina.html
@@ -1136,7 +1136,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/hagerty-north-carolina.html
+++ b/auto-center/carriers/hagerty-north-carolina.html
@@ -1194,7 +1194,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/national-general-north-carolina.html
+++ b/auto-center/carriers/national-general-north-carolina.html
@@ -971,7 +971,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/nationwide-north-carolina.html
+++ b/auto-center/carriers/nationwide-north-carolina.html
@@ -1245,7 +1245,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/nc-grange-north-carolina.html
+++ b/auto-center/carriers/nc-grange-north-carolina.html
@@ -985,7 +985,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/progressive-north-carolina.html
+++ b/auto-center/carriers/progressive-north-carolina.html
@@ -1195,7 +1195,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/carriers/travelers-north-carolina.html
+++ b/auto-center/carriers/travelers-north-carolina.html
@@ -971,7 +971,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/auto-center/claims-process-guide.html
+++ b/auto-center/claims-process-guide.html
@@ -1585,7 +1585,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/alamance.html
+++ b/carriers/alamance.html
@@ -1200,7 +1200,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/dairyland.html
+++ b/carriers/dairyland.html
@@ -1252,7 +1252,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/foremost.html
+++ b/carriers/foremost.html
@@ -1198,7 +1198,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/hagerty.html
+++ b/carriers/hagerty.html
@@ -1252,7 +1252,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/national-general.html
+++ b/carriers/national-general.html
@@ -1286,7 +1286,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/nationwide.html
+++ b/carriers/nationwide.html
@@ -1245,7 +1245,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/nc-grange.html
+++ b/carriers/nc-grange.html
@@ -1268,7 +1268,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/progressive.html
+++ b/carriers/progressive.html
@@ -1228,7 +1228,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/carriers/travelers.html
+++ b/carriers/travelers.html
@@ -1312,7 +1312,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/claims-center/carrier-contacts.html
+++ b/claims-center/carrier-contacts.html
@@ -1384,7 +1384,7 @@
         // Animate elements on scroll
         const observerOptions = {
             threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+            rootMargin: '0px 0px 200px 0px'
         };
 
         const observer = new IntersectionObserver(function(entries) {

--- a/index.html
+++ b/index.html
@@ -2184,7 +2184,7 @@
             // Reveal animations
             const observer = new IntersectionObserver((entries) => {
                 entries.forEach(entry => { if (entry.isIntersecting) entry.target.classList.add('active'); });
-            }, { threshold: 0.05, rootMargin: '0px 0px 50px 0px' });
+            }, { threshold: 0.05, rootMargin: '0px 0px 200px 0px' });
             document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 
             // Testimonial Auto-Rotation (mobile only)


### PR DESCRIPTION
## Summary
- Increased IntersectionObserver `rootMargin` from `50px`/`-50px` to `200px` across 21 pages
- Content now starts revealing 200px before entering the viewport instead of after
- Eliminates blank white space visitors see when scrolling at normal speed

## Pages updated
- Homepage (`index.html`)
- 9 carrier pages (`carriers/*.html`)
- 9 auto-center carrier pages (`auto-center/carriers/*.html`)
- Claims process guide and carrier contacts pages

## Test plan
- [ ] Scroll through homepage at normal/fast speed — no blank white space
- [ ] Scroll through carrier pages — content reveals smoothly
- [ ] Verify reveal animations still look smooth on slow scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)