### PR TITLE
Hide Messenger float on mobile, add to dock menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,7 +708,7 @@
         .messenger-float:active{transform:scale(0.95)}
         .messenger-float .pulse-ring{position:absolute;width:100%;height:100%;border-radius:50%;border:2px solid rgba(0,120,255,0.4);animation:msgPulse 2.5s ease-out infinite}
         @keyframes msgPulse{0%{transform:scale(1);opacity:0.6}100%{transform:scale(1.6);opacity:0}}
-        @media(max-width:768px){.messenger-float{bottom:80px;right:14px;width:54px;height:54px;font-size:24px}}
+        @media(max-width:768px){.messenger-float{display:none}}
         .accordion-content { transition: max-height 0.3s ease, opacity 0.3s ease; max-height: 0; opacity: 0; overflow: hidden; }
         .accordion-content.open { opacity: 1; }
         .pb-safe { padding-bottom: env(safe-area-inset-bottom); }
@@ -2286,6 +2286,7 @@
             <li><a href="https://www.billlayneinsurance.com/service-center.html"><span class="menu-icon green"><i class="fas fa-concierge-bell"></i></span> Service Center <i class="fas fa-chevron-right menu-arrow"></i></a></li>
             <li><a href="https://www.billlayneinsurance.com/contact-us.html"><span class="menu-icon blue"><i class="fas fa-envelope"></i></span> Contact Us <i class="fas fa-chevron-right menu-arrow"></i></a></li>
             <li><a href="https://www.billlayneinsurance.com/espanol/"><span class="menu-icon green"><i class="fas fa-globe-americas"></i></span> Espa&ntilde;ol &#127474;&#127485; <i class="fas fa-chevron-right menu-arrow"></i></a></li>
+            <li style="margin-top:8px;border-top:1px solid rgba(255,255,255,0.08);padding-top:8px"><a href="https://m.me/dollarbillagency" target="_blank"><span class="menu-icon blue" style="background:linear-gradient(135deg,#0078FF,#00C6FF)"><i class="fab fa-facebook-messenger"></i></span> Message Us on Facebook <i class="fas fa-chevron-right menu-arrow"></i></a></li>
         </ul>
     </div>
 


### PR DESCRIPTION
## Summary
- Hide floating Messenger icon on mobile (below 768px) — was overlapping content and competing with mobile dock bar
- Add "Message Us on Facebook" link to the mobile dock slide-up menu panel
- Desktop float unchanged (still visible at 769px+)

## Test plan
- [ ] Mobile: Messenger float icon should NOT appear
- [ ] Mobile: Open dock menu → "Message Us on Facebook" link at bottom with separator
- [ ] Desktop: Blue Messenger float still visible bottom-right
- [ ] Messenger link opens m.me/dollarbillagency in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)