### PR TITLE
Remove social media section from Resources page

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -555,52 +555,6 @@
         </div>
     </section>
 
-    <!-- SOCIAL MEDIA -->
-    <section class="py-8 md:py-24 bg-gradient-to-br from-slate-50 to-indigo-50 border-t border-white">
-        <div class="max-w-7xl mx-auto px-4 sm:px-6">
-            <div class="text-center mb-4 md:mb-16 reveal">
-                <span class="text-indigo-600 font-bold tracking-wider uppercase text-xs bg-white px-4 py-1.5 rounded-full border border-indigo-100 mb-3 inline-block shadow-sm">Community</span>
-                <h2 class="text-xl md:text-4xl font-display font-extrabold text-slate-900 mt-2 md:mt-4 mb-1 md:mb-3">Join Our Network</h2>
-                <p class="text-slate-500 text-sm md:text-lg">Money-saving tips and local updates.</p>
-            </div>
-
-            <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6">
-                <a href="https://www.youtube.com/@ncautoandhome" target="_blank" class="group relative overflow-hidden rounded-xl md:rounded-3xl p-4 sm:p-8 hover:-translate-y-2 hover:shadow-xl transition-all duration-300 reveal">
-                    <div class="absolute inset-0 bg-gradient-to-br from-[#FF0000] to-[#CC0000] opacity-90 group-hover:opacity-100 transition-opacity"></div>
-                    <div class="relative z-10 flex flex-col items-center text-center text-white">
-                        <i class="fab fa-youtube text-2xl md:text-4xl mb-2 md:mb-4 bg-white/20 p-2.5 md:p-4 rounded-xl md:rounded-2xl backdrop-blur-sm"></i>
-                        <h3 class="font-bold text-sm md:text-xl">YouTube</h3>
-                        <span class="mt-4 px-4 py-1 bg-white text-red-600 rounded-full text-xs font-bold">Subscribe</span>
-                    </div>
-                </a>
-                <a href="https://www.facebook.com/dollarbillagency/" target="_blank" class="group relative overflow-hidden rounded-xl md:rounded-3xl p-4 sm:p-8 hover:-translate-y-2 hover:shadow-xl transition-all duration-300 reveal delay-100">
-                    <div class="absolute inset-0 bg-gradient-to-br from-[#1877F2] to-[#0C5DC7] opacity-90 group-hover:opacity-100 transition-opacity"></div>
-                    <div class="relative z-10 flex flex-col items-center text-center text-white">
-                        <i class="fab fa-facebook-f text-2xl md:text-4xl mb-2 md:mb-4 bg-white/20 p-2.5 md:p-4 rounded-xl md:rounded-2xl backdrop-blur-sm"></i>
-                        <h3 class="font-bold text-sm md:text-xl">Facebook</h3>
-                        <span class="mt-4 px-4 py-1 bg-white text-blue-600 rounded-full text-xs font-bold">Follow</span>
-                    </div>
-                </a>
-                <a href="https://www.instagram.com/ncautoandhome/" target="_blank" class="group relative overflow-hidden rounded-xl md:rounded-3xl p-4 sm:p-8 hover:-translate-y-2 hover:shadow-xl transition-all duration-300 reveal delay-200">
-                    <div class="absolute inset-0 bg-gradient-to-br from-[#833AB4] via-[#FD1D1D] to-[#F77737] opacity-90 group-hover:opacity-100 transition-opacity"></div>
-                    <div class="relative z-10 flex flex-col items-center text-center text-white">
-                        <i class="fab fa-instagram text-2xl md:text-4xl mb-2 md:mb-4 bg-white/20 p-2.5 md:p-4 rounded-xl md:rounded-2xl backdrop-blur-sm"></i>
-                        <h3 class="font-bold text-sm md:text-xl">Instagram</h3>
-                        <span class="mt-4 px-4 py-1 bg-white text-purple-600 rounded-full text-xs font-bold">Follow</span>
-                    </div>
-                </a>
-                <a href="https://x.com/shopsavecompare" target="_blank" class="group relative overflow-hidden rounded-xl md:rounded-3xl p-4 sm:p-8 hover:-translate-y-2 hover:shadow-xl transition-all duration-300 reveal delay-300">
-                    <div class="absolute inset-0 bg-gradient-to-br from-slate-800 to-black opacity-90 group-hover:opacity-100 transition-opacity"></div>
-                    <div class="relative z-10 flex flex-col items-center text-center text-white">
-                        <i class="fab fa-x-twitter text-2xl md:text-4xl mb-2 md:mb-4 bg-white/20 p-2.5 md:p-4 rounded-xl md:rounded-2xl backdrop-blur-sm"></i>
-                        <h3 class="font-bold text-sm md:text-xl">X / Twitter</h3>
-                        <span class="mt-4 px-4 py-1 bg-white text-slate-900 rounded-full text-xs font-bold">Follow</span>
-                    </div>
-                </a>
-            </div>
-        </div>
-    </section>
-
     <!-- Why Choose an Independent Agent -->
     <section class="py-10 md:py-16 bg-gradient-to-r from-slate-800 to-slate-900 text-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 text-center">
@@ -617,9 +571,11 @@
             <div class="col-span-1 md:col-span-1">
                 <h4 class="text-white font-display font-bold text-xl mb-6">Bill Layne Insurance</h4>
                 <p class="text-sm leading-relaxed mb-6">Protecting families in North Carolina since 2005. We are your local, trusted, and independent agency.</p>
-                <div class="flex gap-4">
-                    <a href="https://www.facebook.com/dollarbillagency/" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-blue-600 transition-all"><i class="fab fa-facebook-f"></i></a>
-                    <a href="https://www.instagram.com/ncautoandhome/" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-purple-500 transition-all"><i class="fab fa-instagram"></i></a>
+                <div class="flex gap-3">
+                    <a href="https://www.facebook.com/dollarbillagency/" target="_blank" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-blue-600 transition-all"><i class="fab fa-facebook-f"></i></a>
+                    <a href="https://www.instagram.com/ncautoandhome/" target="_blank" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-purple-500 transition-all"><i class="fab fa-instagram"></i></a>
+                    <a href="https://www.youtube.com/@ncautoandhome" target="_blank" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-red-600 transition-all"><i class="fab fa-youtube"></i></a>
+                    <a href="https://x.com/shopsavecompare" target="_blank" class="w-10 h-10 rounded-full bg-slate-800 flex items-center justify-center text-slate-400 hover:text-white hover:bg-slate-600 transition-all"><i class="fab fa-x-twitter"></i></a>
                 </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Removed full "Join Our Network" social media section (consistent with other pages)
- Added YouTube and X/Twitter icons to footer alongside existing Facebook + Instagram

## Test plan
- [x] No console errors
- [x] Social section removed, no "Join Our Network" on page
- [x] Footer has all 4 social icons (Facebook, Instagram, YouTube, X/Twitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)