### PR TITLE
Add Instagram to Service Center footer social icons

### DIFF
--- a/service-center.html
+++ b/service-center.html
@@ -989,9 +989,10 @@
             <div>
                 <h5 class="text-white font-bold mb-4 sm:mb-6 text-sm uppercase tracking-widest">Follow Us</h5>
                 <div class="flex gap-3 sm:gap-4">
-                    <a href="https://www.facebook.com/dollarbillagency/" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-primary-600 transition-all text-white"><i class="fab fa-facebook-f"></i></a>
-                    <a href="https://www.youtube.com/@ncautoandhome" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-red-600 transition-all text-white"><i class="fab fa-youtube"></i></a>
-                    <a href="https://x.com/shopsavecompare" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-slate-700 transition-all text-white"><i class="fab fa-x-twitter"></i></a>
+                    <a href="https://www.facebook.com/dollarbillagency/" target="_blank" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-blue-600 transition-all text-white"><i class="fab fa-facebook-f"></i></a>
+                    <a href="https://www.instagram.com/ncautoandhome/" target="_blank" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-purple-500 transition-all text-white"><i class="fab fa-instagram"></i></a>
+                    <a href="https://www.youtube.com/@ncautoandhome" target="_blank" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-red-600 transition-all text-white"><i class="fab fa-youtube"></i></a>
+                    <a href="https://x.com/shopsavecompare" target="_blank" class="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center hover:bg-slate-700 transition-all text-white"><i class="fab fa-x-twitter"></i></a>
                 </div>
                 <!-- Footer Logo -->
                 <div class="mt-8">


### PR DESCRIPTION
## Summary
- Added missing Instagram icon to footer (now has all 4: Facebook, Instagram, YouTube, X/Twitter)
- Added `target="_blank"` to all footer social links for consistent behavior
- Service Center page was already well-optimized for mobile — no other changes needed

## Test plan
- [x] Footer has all 4 social icons
- [x] All social links open in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)