### PR TITLE
Fix mobile menu hiding Home link on open

### DIFF
--- a/css/mobile-dock.css
+++ b/css/mobile-dock.css
@@ -109,6 +109,9 @@
     bottom: 0;
     left: 0;
     width: 100%;
+    max-height: 85vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
     z-index: 95;
     background: white;
     border-radius: 24px 24px 0 0;

--- a/js/mobile-dock.js
+++ b/js/mobile-dock.js
@@ -5,5 +5,8 @@ function toggleMobileDockMenu() {
     if (overlay && panel) {
         overlay.classList.toggle('open');
         panel.classList.toggle('open');
+        if (panel.classList.contains('open')) {
+            panel.scrollTop = 0;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Mobile dock menu panel had no `max-height` or `overflow-y`, so with 12+ menu items the list extended beyond the viewport — Home was above the visible area
- Added `max-height: 85vh` and `overflow-y: auto` to `.menu-panel` so the menu is scrollable within the viewport
- Added `scrollTop = 0` reset when menu opens so Home is always the first visible item

## Test plan
- [ ] Open menu on mobile — Home should be visible at the top
- [ ] Scroll down in menu, close and reopen — should reset to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)