### PR TITLE
Style homepage Easier Than An App cards for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1309,31 +1309,31 @@
             <!-- 3-Step Process — Resource-style cards -->
             <div class="grid sm:grid-cols-3 gap-4 md:gap-6 relative">
 
-                <div class="group bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-blue-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden reveal">
-                    <div class="absolute top-0 right-0 w-32 h-32 bg-blue-50 rounded-bl-full opacity-50 group-hover:bg-blue-100 transition-colors"></div>
+                <div class="group bg-blue-50 sm:bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-blue-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden text-center sm:text-left reveal">
+                    <div class="absolute top-0 right-0 w-32 h-32 bg-blue-100 sm:bg-blue-50 rounded-bl-full opacity-50 group-hover:bg-blue-100 transition-colors"></div>
                     <div class="relative z-10">
                         <div class="inline-flex items-center justify-center w-8 h-8 bg-slate-900 text-white rounded-full text-sm font-black mb-3">1</div>
-                        <div class="w-12 h-12 md:w-14 md:h-14 bg-blue-50 rounded-xl md:rounded-2xl flex items-center justify-center text-blue-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform"><i class="fas fa-mobile-alt"></i></div>
+                        <div class="w-12 h-12 md:w-14 md:h-14 bg-white sm:bg-blue-50 rounded-xl md:rounded-2xl flex items-center justify-center text-blue-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform mx-auto sm:mx-0"><i class="fas fa-mobile-alt"></i></div>
                         <h3 class="text-base md:text-xl font-bold text-slate-900 mb-2">5-Minute Chat</h3>
                         <p class="text-slate-500 leading-relaxed text-xs md:text-sm">Enter your zip, snap a photo of your current policy, or just call. No bots &mdash; a real pro reviews everything.</p>
                     </div>
                 </div>
 
-                <div class="group bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-amber-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden reveal" style="transition-delay: 0.15s;">
-                    <div class="absolute top-0 right-0 w-32 h-32 bg-amber-50 rounded-bl-full opacity-50 group-hover:bg-amber-100 transition-colors"></div>
+                <div class="group bg-amber-50 sm:bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-amber-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden text-center sm:text-left reveal" style="transition-delay: 0.15s;">
+                    <div class="absolute top-0 right-0 w-32 h-32 bg-amber-100 sm:bg-amber-50 rounded-bl-full opacity-50 group-hover:bg-amber-100 transition-colors"></div>
                     <div class="relative z-10">
                         <div class="inline-flex items-center justify-center w-8 h-8 bg-slate-900 text-white rounded-full text-sm font-black mb-3">2</div>
-                        <div class="w-12 h-12 md:w-14 md:h-14 bg-amber-50 rounded-xl md:rounded-2xl flex items-center justify-center text-amber-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform"><i class="fas fa-search-dollar"></i></div>
+                        <div class="w-12 h-12 md:w-14 md:h-14 bg-white sm:bg-amber-50 rounded-xl md:rounded-2xl flex items-center justify-center text-amber-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform mx-auto sm:mx-0"><i class="fas fa-search-dollar"></i></div>
                         <h3 class="text-base md:text-xl font-bold text-slate-900 mb-2">We Shop &amp; Compare</h3>
                         <p class="text-slate-500 leading-relaxed text-xs md:text-sm">We force carriers like Travelers &amp; Progressive to compete for your business. Side-by-side comparison &mdash; no pressure.</p>
                     </div>
                 </div>
 
-                <div class="group bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-green-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden reveal" style="transition-delay: 0.3s;">
-                    <div class="absolute top-0 right-0 w-32 h-32 bg-green-50 rounded-bl-full opacity-50 group-hover:bg-green-100 transition-colors"></div>
+                <div class="group bg-green-50 sm:bg-white p-5 sm:p-6 md:p-8 rounded-2xl md:rounded-[2rem] shadow-sm border border-green-100 hover:shadow-xl hover:-translate-y-1 transition-all duration-300 relative overflow-hidden text-center sm:text-left reveal" style="transition-delay: 0.3s;">
+                    <div class="absolute top-0 right-0 w-32 h-32 bg-green-100 sm:bg-green-50 rounded-bl-full opacity-50 group-hover:bg-green-100 transition-colors"></div>
                     <div class="relative z-10">
                         <div class="inline-flex items-center justify-center w-8 h-8 bg-slate-900 text-white rounded-full text-sm font-black mb-3">3</div>
-                        <div class="w-12 h-12 md:w-14 md:h-14 bg-green-50 rounded-xl md:rounded-2xl flex items-center justify-center text-green-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform"><i class="fas fa-signature"></i></div>
+                        <div class="w-12 h-12 md:w-14 md:h-14 bg-white sm:bg-green-50 rounded-xl md:rounded-2xl flex items-center justify-center text-green-600 text-xl md:text-2xl mb-4 shadow-sm group-hover:scale-110 transition-transform mx-auto sm:mx-0"><i class="fas fa-signature"></i></div>
                         <h3 class="text-base md:text-xl font-bold text-slate-900 mb-2">E-Sign &amp; You're Done</h3>
                         <p class="text-slate-500 leading-relaxed text-xs md:text-sm">E-sign from your phone. We cancel your old policy and notify your lender. That's it.</p>
                     </div>


### PR DESCRIPTION
## Summary
- Centered icons, step numbers, titles, and text on mobile viewport
- Added colored backgrounds per card: blue-50 (step 1), amber-50 (step 2), green-50 (step 3)
- White icon badges for contrast against colored backgrounds
- Desktop layout remains left-aligned with white backgrounds via `sm:` breakpoints

## Test plan
- [x] Verified on mobile (375px) — all 3 cards centered with colored backgrounds
- [ ] Desktop check — cards remain white with left alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)